### PR TITLE
WSL Patch for RSYNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired by [Sublime SFTP](http://wbond.net/sublime_packages/sftp).
 [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)[![Build Status](https://travis-ci.org/dingjie/atom-sync.svg?branch=master)](https://travis-ci.org/dingjie/atom-sync)
 
 
-> This package is a clone of atom-sync and has a patch to use cygwin emulation on Windows.
+> This package is a clone of atom-sync and has a patch to use cygwin (or Windows Subsystem for Linux) emulation on Windows.
 If you install "openssh rsync" on windows via cygwin (https://cygwin.org),
 then you can use the plugin also on Windows which then emulates the rsync inside cygwin.
 You need to put your C:/cygwin/bin/ in to %PATH% so that ssh and rsync are used on cmd.exe or atom.exe .
@@ -27,8 +27,9 @@ but much [faster](http://stackoverflow.com/questions/20244585/what-is-the-differ
 
 ### Prerequisite ###
 * Ensure you have `ssh` and `rsync` installed.
+* Alternatively ensure you have ubuntu `bash` installed.
 
-* Special on Windows
+* Special on Windows - Cygwin
   * Install Cygwin from https://cygwin.org
   * Select "openssh" and "rsync" from packages and install them
   * rsync is now available in the cygwin-terminal, but not visible from atom
@@ -43,12 +44,15 @@ but much [faster](http://stackoverflow.com/questions/20244585/what-is-the-differ
   * Add Path to your Cygwin-Installation e.g. "C:\cygwin\bin"
   * close dialogs
 
+* Special on Windows - WSL
+  * Install Windows Subsystem for Linux https://msdn.microsoft.com/en-us/commandline/wsl/install-win10
+
 * now atom should be able to use ssh + rsync
   * to properly use ssh without password with autorized_keys, you need to have .ssh folder etc.
   * in cygwin you can open "cygwin terminal" and check by "ls .ssh"
+  * in WSL you can open "bash" and check by "ls .ssh"
   * maybe you need to create a pub-key with "ssh-keygen", look in internet for further instructions.
   * best to create a pub-key without password, so that you don't have to type password always.
-
 
 ### Quick Start ###
 * Open a project folder to sync in [Atom](http://atom.io).
@@ -78,6 +82,7 @@ behaviour:
     alwaysSyncAll: false    # Sync all files and folders under the project \
                             # instead of syncing single file or folder
 option:
+    wsl: false              # Enable Windows Subsystem for Linux mode
     deleteFiles: true       # Delete files during syncing
     autoHideDelay: 1500     # Time delay to hide console
     exclude: [              # Excluding patterns
@@ -151,6 +156,7 @@ Host *
 
 ### Known Problems ###
 * You have to `Sync Local -> Remote` manually after renaming and deleting files.
+* Triggers not yet functional on WSL.  If you have git bash installed ensure your .ssh folder matches between C:\\Users\\username\\.ssh and your WSL home folder and triggers should still function.
 
 ### Roadmap ###
 * Listen to events

--- a/bin/rsync.bat
+++ b/bin/rsync.bat
@@ -1,0 +1,6 @@
+@echo off
+if %PROCESSOR_ARCHITECTURE%==x86 (
+  %SYSTEMROOT%\Sysnative\bash.exe -c "rsync %*"
+) else (
+  %SYSTEMROOT%\System32\bash.exe -c "rsync %*"
+)

--- a/lib/controller/service-controller.coffee
+++ b/lib/controller/service-controller.coffee
@@ -88,14 +88,25 @@ module.exports = ServiceController =
     delay = config.option?.autoHideDelay or 1500
 
     # Fix Unix Path Delimiters for windows with help of cygwin
-    src = src.replace /\\/g, "/"
-    src = src.replace /^([A-Z])\:/ , "/cygdrive/$1"
-    dst = dst.replace /\\/g, "/"
-    dst = dst.replace /^([A-Z])\:/ , "/cygdrive/$1"
+    if config.option?.wsl is true
+      exe = '"' + path.join __dirname, '..', '..', 'bin', 'rsync.bat' + '"'
+      src = src.replace /\\/g, "/"
+      src = src.replace /^([A-Z])\:/ , (search, match) ->
+        "/mnt/" + match.toLowerCase()
+      dst = dst.replace /\\/g, "/"
+      dst = dst.replace /^([A-Z])\:/ , (search, match) ->
+        "/mnt/" + match.toLowerCase()
+    else
+      src = src.replace /\\/g, "/"
+      src = src.replace /^([A-Z])\:/ , "/cygdrive/$1"
+      dst = dst.replace /\\/g, "/"
+      dst = dst.replace /^([A-Z])\:/ , "/cygdrive/$1"
+
     @console.show() if not config.behaviour.forgetConsole
     @console.info "=> Syncing from #{src} \n  ... to #{dst} \n"
 
     (require '../service/' + provider)
+      exe: exe,
       src: src,
       dst: dst,
       config: config,

--- a/lib/helper/config-helper.coffee
+++ b/lib/helper/config-helper.coffee
@@ -51,6 +51,7 @@ module.exports = ConfigHelper =
       autoHideConsole: true
       alwaysSyncAll: false
     option:
+      wsl: false
       deleteFiles: false
       exclude: [
         '.sync-config.cson'

--- a/lib/service/rsync-service.coffee
+++ b/lib/service/rsync-service.coffee
@@ -23,6 +23,7 @@ yellowpage =
   255: 'SSH connection failed'
 
 module.exports = (opt = {}) ->
+  exe = opt?.exe ? 'rsync'
   src = opt.src
   dst = opt.dst
   config = opt.config
@@ -33,6 +34,7 @@ module.exports = (opt = {}) ->
   shell = config.option?.shell ? 'ssh'
 
   rsync = new Rsync()
+    .executable exe
     .shell shell
     .flags flags
     .source src


### PR DESCRIPTION
Add in Windows Subsystem for Linux capabilities.
The node-rsync package allows modifying the executable.  Added batch script to execute the command correctly on Ubuntu Bash.
Still missing ssh workaround for triggers as node-openssh doesn't allow swapping out the executable.  Added to readme notes about using native git ssh and keeping .ssh folders matching between C:\Users\username\.ssh and bash home folder.