### PR TITLE
add chmod option for rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ option:
         'vendor'
     ]
     flags: 'avzpur'         # Advanced option: rsync flags
+    #chmods: 'Du=rwx,Dgo=rx,Fu=rw,Fog=r' #force the permissions to be set to 755 for Directories and 644 for Files
     shell: 'ssh'
     # or
     #shell: '/usr/bin/sshpass -p password ssh -o StrictHostKeyChecking=no -l username'


### PR DESCRIPTION
fixed : add force permission for rsync

i found permission is invalid. , using rsync from window cygwin
--no-perms is not work.

The option to ignore NTFS permissions has changed in Cygwin version 1.7. This might be what's causing the problem.

ref: https://stackoverflow.com/questions/5798807/rsync-on-windows-wrong-permissions-for-created-directories