### PR TITLE
Add support for rsync `--exclude-from`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NOTICE !
 
-i switched over to PHPStorm and don't use Atom.io anymore. Intellisense/Autocomplete etc. is 100x better than in atom.io. 
-Feel free to use the plugin, but i will probably not update much. 
+i switched over to PHPStorm and don't use Atom.io anymore. Intellisense/Autocomplete etc. is 100x better than in atom.io.
+Feel free to use the plugin, but i will probably not update much.
 
 # atom-sync-cygwin package
 
@@ -90,7 +90,8 @@ option:
     wsl: false              # Enable Windows Subsystem for Linux mode
     deleteFiles: true       # Delete files during syncing
     autoHideDelay: 1500     # Time delay to hide console
-    exclude: [              # Excluding patterns
+    #excludeFrom: '/absolute/path/to/exclude/file' # Use rsync exclude file
+    exclude: [              # Excluding patterns (leave empty array if only using excludeFrom)
         '.sync-config.cson'
         '.git'
         'node_modules'

--- a/lib/service/rsync-service.coffee
+++ b/lib/service/rsync-service.coffee
@@ -43,6 +43,7 @@ module.exports = (opt = {}) ->
       progress? data.toString('utf-8').trim()
 
   rsync.set 'chmod' , config.option.chmods if config.option?.chmods
+  rsync.set 'exclude-from', config.option.excludeFrom if config.option?.excludeFrom
   rsync.delete() if config.option?.deleteFiles
   rsync.exclude config.option.exclude if config.option?.exclude
   rsync.execute (err, code, cmd) =>


### PR DESCRIPTION
This is uncommon, but I ran into a use case where I needed to exclude a number of generated files all over a source tree when xferring to a remote system. It's possible that using `exclude` for each file could exceed the command line length for `rsync` in extreme cases, so I elected to add support for `--exclude-from`, using the config file option `excludeFrom`.

I tested this and it works fine, even in combination with `exclude`! However, the main limitation is that the path must be absolute- from the scope where rsync is invoked in this package, I'm unsure how to make the exclude file relative to the project root (nor whether it's even desirable).

I understand you no longer use Atom, but I am open to feedback and changes nonetheless :).